### PR TITLE
Split undefined bug - Subrip files that has CR+LF

### DIFF
--- a/SubPlayerJS.js
+++ b/SubPlayerJS.js
@@ -511,10 +511,12 @@ class SubPlayerJS {
     } 
 
     static parseSubRip(srt, videoid){
-        var lines = srt.split(/[\r\n]+/g); // CR+LF
+		var lines = srt.replaceAll("\r",""); //in case each line ended with cr+lf
+		lines = lines.split(/[\r\n]+[\r\n]+/);
+        
         $.each(lines, function(key, line) {
             if (line.indexOf("-->") > -1) {
-                var parts = line.split(/[\r\n]+/)[0].split('-->');
+				var parts = line.split(/[\r\n]+/)[1].split(/[\r\n]+/)[0].split('-->');
                 parts[0] = SubPlayerJS.timeStampToSeconds(parts[0], "srt");
                 parts[1] = SubPlayerJS.timeStampToSeconds(parts[1], "srt");
 

--- a/SubPlayerJS.js
+++ b/SubPlayerJS.js
@@ -511,10 +511,10 @@ class SubPlayerJS {
     } 
 
     static parseSubRip(srt, videoid){
-        var lines = srt.split(/[\r\n]+[\r\n]+/);
+        var lines = srt.split(/[\r\n]+/g); // CR+LF
         $.each(lines, function(key, line) {
             if (line.indexOf("-->") > -1) {
-                var parts = line.split(/[\r\n]+/)[1].split(/[\r\n]+/)[0].split('-->');
+                var parts = line.split(/[\r\n]+/)[0].split('-->');
                 parts[0] = SubPlayerJS.timeStampToSeconds(parts[0], "srt");
                 parts[1] = SubPlayerJS.timeStampToSeconds(parts[1], "srt");
 

--- a/demo.html
+++ b/demo.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <title> Demo Player </title>
-<script type="text/javascript" src="https://rawgit.com/EldinZenderink/SubPlayerJS/master/SubPlayerJS.js" ></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/EldinZenderink/SubPlayerJS@master/SubPlayerJS.js" ></script>
 </head>
 <body>
 


### PR DESCRIPTION
SRT files that their each line end with _CR+LF_ don't work with current algorithm because each dialog is not grouped in one **line** and therefore text and timing is not separated. 

for this code to work we need to have only "LF" .

------------
also rawgit is closing down, so i changed to jsdeliver.